### PR TITLE
Method to encode header content ID, plus test

### DIFF
--- a/eth_portal/web3_encoding.py
+++ b/eth_portal/web3_encoding.py
@@ -1,0 +1,31 @@
+import ssz
+from ssz.sedes import (
+    Container,
+    Vector,
+    uint8,
+    uint16,
+)
+
+#
+# SSZ encoding
+#
+
+HEADER_TYPE_BYTE = b'\x01'
+HEADER_SEDES = Container((
+    uint16,  # Chain ID
+    Vector(uint8, 32),  # header hash
+))
+
+
+def header_content_id(header_hash, chain_id=1):
+    """
+    Convert a header hash into a content ID for the Portal History Network.
+
+    Include the chain ID, which defaults to mainnet.
+    """
+    # The header type ID is implicitly defined in the SSZ union which
+    # specifies the content ID on the header history network.
+    encoded = ssz.encode((chain_id, header_hash), HEADER_SEDES)
+
+    # I don't think py-ssz supports Union types, so manually tacking it on
+    return HEADER_TYPE_BYTE + encoded

--- a/newsfragments/2.internal.rst
+++ b/newsfragments/2.internal.rst
@@ -1,0 +1,1 @@
+Add support for converting a header hash into a Portal History Network Content ID

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     install_requires=[
         "web3>=5,<6",
         "py-evm==0.5.0-alpha.3",
+        "ssz<0.3.0,>=0.2.0",
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,

--- a/tests/core/test_web3_encoding.py
+++ b/tests/core/test_web3_encoding.py
@@ -1,0 +1,16 @@
+import pytest
+
+from eth_portal.web3_encoding import (
+    header_content_id,
+)
+
+
+@pytest.mark.parametrize(
+    'chain_id, header_hash, expected_encoding',
+    (
+        (2, b'H' * 32, b'\x01\x02\x00' + b'H' * 32),
+    )
+)
+def test_encode_header(chain_id, header_hash, expected_encoding):
+    content_id = header_content_id(header_hash, chain_id)
+    assert content_id == expected_encoding


### PR DESCRIPTION
## What was wrong?

No convenient method for encoding the header content ID.

## How was it fixed?

Added py-ssz dependency. Add a method that uses it, plus a small hack for Union support.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.wallpaperup.com/uploads/wallpapers/2014/02/18/258591/03e554f1d7d02290c22a78edf6241ce2-700.jpg)