### PR TITLE
Encode receipt key

### DIFF
--- a/eth_portal/web3_encoding.py
+++ b/eth_portal/web3_encoding.py
@@ -11,7 +11,8 @@ from ssz.sedes import (
 #
 
 HEADER_TYPE_BYTE = b'\x00'
-HEADER_SEDES = Container((
+RECEIPT_TYPE_BYTE = b'\x02'
+BLOCK_KEY_SEDES = Container((
     uint16,  # Chain ID
     Vector(uint8, 32),  # header hash
 ))
@@ -19,13 +20,24 @@ HEADER_SEDES = Container((
 
 def header_content_key(header_hash, chain_id=1):
     """
-    Convert a header hash into a content key for the Portal History Network.
+    Convert a header hash into a header content key for the Portal History Network.
 
     Include the chain ID, which defaults to mainnet.
     """
     # The header type ID is implicitly defined in the SSZ union which
     # specifies the content key on the header history network.
-    encoded = ssz.encode((chain_id, header_hash), HEADER_SEDES)
+    encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
 
     # I don't think py-ssz supports Union types, so manually tacking it on
     return HEADER_TYPE_BYTE + encoded
+
+
+def receipt_content_key(header_hash, chain_id=1):
+    """
+    Convert a header hash into a receipt content key for the Portal History Network.
+
+    Include the chain ID, which defaults to mainnet.
+    """
+    # See implementation notes in header_content_key()
+    encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
+    return RECEIPT_TYPE_BYTE + encoded

--- a/newsfragments/7.feature.rst
+++ b/newsfragments/7.feature.rst
@@ -1,0 +1,1 @@
+Utility to encode the content key for block receipts

--- a/tests/core/test_web3_decoding.py
+++ b/tests/core/test_web3_decoding.py
@@ -10,5 +10,6 @@ from eth_portal.web3_decoding import (
 
 def test_web3_header_to_rlp(web3_block):
     header = block_fields_to_header(web3_block)
+    assert header.hash == web3_block.hash
     header_rlp = rlp.encode(header)
     assert keccak(header_rlp) == web3_block.hash

--- a/tests/core/test_web3_encoding.py
+++ b/tests/core/test_web3_encoding.py
@@ -5,6 +5,7 @@ import pytest
 
 from eth_portal.web3_encoding import (
     header_content_key,
+    receipt_content_key,
 )
 
 
@@ -21,6 +22,24 @@ from eth_portal.web3_encoding import (
         ),
     )
 )
-def test_encode_header(chain_id, header_hash, expected_encoding):
+def test_encode_header_key(chain_id, header_hash, expected_encoding):
     content_key = header_content_key(header_hash, chain_id)
+    assert content_key == expected_encoding
+
+
+@pytest.mark.parametrize(
+    'chain_id, header_hash, expected_encoding',
+    (
+        (2, b'H' * 32, b'\x02\x02\x00' + b'H' * 32),
+        (
+            # Pulled test data from:
+            # https://github.com/ethereum/portal-network-specs/blob/2fb0116314c407feff4ce678dac2da5adea834eb/content-keys-test-vectors.md#headerkey
+            4,
+            decode_hex('0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'),
+            decode_hex('0x020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d'),
+        ),
+    )
+)
+def test_encode_receipt_key(chain_id, header_hash, expected_encoding):
+    content_key = receipt_content_key(header_hash, chain_id)
     assert content_key == expected_encoding


### PR DESCRIPTION
Also, do some refactoring

    - Reorder arguments for more consistency with other propagation
    - Return block info after propagation, for other types of data propagation
    - Use web3's newer snake_case
    - Extra hash check
    - Document returning the content key and value

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/3b/25/4e/3b254efa7fa7c320de059fc0579fe3f8.png)
