### PR TITLE
Encode Receipts to content key & value

### DIFF
--- a/eth_portal/web3_encoding.py
+++ b/eth_portal/web3_encoding.py
@@ -1,6 +1,8 @@
 import ssz
 from ssz.sedes import (
+    Byte,
     Container,
+    List,
     Vector,
     uint8,
     uint16,
@@ -16,6 +18,12 @@ BLOCK_KEY_SEDES = Container((
     uint16,  # Chain ID
     Vector(uint8, 32),  # header hash
 ))
+
+BLOCK_RECEIPTS_SEDES = List(
+    # Each encoded receipt
+    List(Byte(), 65535),  # TODO identify true upper-bound on encoded receipt length
+    65535,  # 2**16-1 receipts would use up >1.3 billion gas at 21k gas each
+)
 
 
 def header_content_key(header_hash, chain_id=1):
@@ -41,3 +49,15 @@ def receipt_content_key(header_hash, chain_id=1):
     # See implementation notes in header_content_key()
     encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
     return RECEIPT_TYPE_BYTE + encoded
+
+
+def receipt_content_value(receipts) -> bytes:
+    """
+    Compile a list of encoded receipts into their joined content value.
+    """
+    # Awkward quirk that ssz must take an iterable of individual bytes, instead of `bytes`
+    quirky_byte_list = [
+        [bytes([byte]) for byte in receipt.encode()]
+        for receipt in receipts
+    ]
+    return ssz.encode(quirky_byte_list, BLOCK_RECEIPTS_SEDES)

--- a/newsfragments/10.feature.rst
+++ b/newsfragments/10.feature.rst
@@ -1,0 +1,2 @@
+Utility to encode a group of receipts to its Portal Network content value. Currently assumes that we
+switch to using an SSZ list from the RLP list.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -26,6 +26,8 @@ def block_info_and_web3_receipts():
             (
                 # block number
                 14764013,
+                # header hash
+                HexBytes('0x720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c'),
                 # receipt root
                 HexBytes('0x168a3827607627e781941dc777737fc4b6beb69a8b139240b881992b35b854ea'),
             ),

--- a/tests/core/test_web3_decoding.py
+++ b/tests/core/test_web3_decoding.py
@@ -1,5 +1,5 @@
 from eth.db.trie import (
-    _make_trie_root_and_nodes,
+    make_trie_root_and_nodes,
 )
 from eth_hash.auto import (
     keccak,
@@ -23,7 +23,7 @@ def test_web3_header_to_rlp(web3_block):
 
 
 def test_receipt_root_from_fields(block_info_and_web3_receipts):
-    (block_number, receipt_root), web3_receipts = block_info_and_web3_receipts
+    (block_number, _, receipt_root), web3_receipts = block_info_and_web3_receipts
     receipts = [
         receipt_fields_to_receipt(web3_receipt, block_number)
         for web3_receipt in web3_receipts
@@ -54,6 +54,6 @@ def test_receipt_root_from_fields(block_info_and_web3_receipts):
         assert receipt.gas_used == web3_receipt.cumulativeGasUsed
 
     # Compare to receipt root
-    calculated_root, _ = _make_trie_root_and_nodes(tuple(receipt.encode() for receipt in receipts))
+    calculated_root, _ = make_trie_root_and_nodes(receipts)
 
     assert calculated_root == receipt_root


### PR DESCRIPTION
For now, use an SSZ list to combine the receipts into a single encoded value.

Discussion here: https://github.com/ethereum/portal-network-specs/issues/149



### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.dumpaday.com/wp-content/uploads/2019/08/1-37.jpg)
