### PR TITLE
Use existing trin node if it is already running

### DIFF
--- a/newsfragments/14.feature.rst
+++ b/newsfragments/14.feature.rst
@@ -1,0 +1,2 @@
+In bridge launcher, detect if trin "injector" node is already running, then use it. One benefit is
+being able to observe the logs on trin during bridge operation.


### PR DESCRIPTION
Also, a convenient log to help you run trin yourself, if desired.

Detect that the node is already running by checking if the IPC path already exists.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/08/cute-animals-twins-8.jpg)
