### PR TITLE
Propagate block bodies

### DIFF
--- a/eth_portal/web3_decode.py
+++ b/eth_portal/web3_decode.py
@@ -60,12 +60,17 @@ def web3_result_to_transaction(web3_transaction, block_number):
     VM = MainnetChain.get_vm_class_for_block_number(block_number)
     TransactionBuilder = VM.block_class.transaction_builder
 
+    if web3_transaction.to:
+        recipient = to_canonical_address(web3_transaction.to)
+    else:
+        recipient = b""
+
     if "type" not in web3_transaction or web3_transaction.type == "0x0":
         return TransactionBuilder.new_transaction(
             web3_transaction.nonce,
             web3_transaction.gasPrice,
             web3_transaction.gas,
-            to_canonical_address(web3_transaction.to),
+            recipient,
             web3_transaction.value,
             to_bytes(hexstr=web3_transaction.input),
             web3_transaction.v,
@@ -78,7 +83,7 @@ def web3_result_to_transaction(web3_transaction, block_number):
             web3_transaction.nonce,
             web3_transaction.gasPrice,
             web3_transaction.gas,
-            to_canonical_address(web3_transaction.to),
+            recipient,
             web3_transaction.value,
             to_bytes(hexstr=web3_transaction.input),
             _normalize_access_list(web3_transaction),
@@ -93,7 +98,7 @@ def web3_result_to_transaction(web3_transaction, block_number):
             web3_transaction.maxPriorityFeePerGas,
             web3_transaction.maxFeePerGas,
             web3_transaction.gas,
-            to_canonical_address(web3_transaction.to),
+            recipient,
             web3_transaction.value,
             to_bytes(hexstr=web3_transaction.input),
             _normalize_access_list(web3_transaction),

--- a/newsfragments/19.feature.rst
+++ b/newsfragments/19.feature.rst
@@ -1,0 +1,1 @@
+Bridge node now propagates block bodies on the Portal History Network.


### PR DESCRIPTION
Pull the full transactions when getting a block, and grab the extra uncle headers. Then package up and push them to trin.

Because we are pulling full transactions now, we don't get the hashes for free. So now, decode transactions once, use the hashes of them to request receipts.

Bonus fix: decode transactions from web3 when they create contracts (`to` field is empty).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTjordqW17BIYmKnwQSffg3lruYV192p_8cdQ&usqp=CAU)