### PR TITLE
Upgrade web3.py to get the longer socket timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     url='https://github.com/ethereum/eth-portal',
     include_package_data=True,
     install_requires=[
-        "web3>=5,<6",
+        "web3>=5.29.2,<6",
         "py-evm==0.5.0-alpha.3",
         "ssz<0.3.0,>=0.2.0",
     ],


### PR DESCRIPTION
See https://github.com/ethereum/web3.py/issues/2483

## What was wrong?

Was getting fatal web3.py socket timeouts.

## How was it fixed?

Upgrade web3.py to use a default timeout of 2s instead of 0.1s.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://post.bark.co/wp-content/uploads/2015/10/10693505_696306837106738_1627632870_n.jpg)
