### PR TITLE
Change the SSZ limits, based on actual network max

### DIFF
--- a/eth_portal/bridge.py
+++ b/eth_portal/bridge.py
@@ -238,16 +238,17 @@ def _encode_block_body_content(
 
     # Convert web3 (uncle) headers into py-evm headers
     uncles = [block_fields_to_header(web3_header) for web3_header in web3_uncles]
+    encoded_uncles = rlp.encode(uncles)
 
     # Validate against the uncles root
-    calculated_uncle_root = keccak(rlp.encode(uncles))
+    calculated_uncle_root = keccak(encoded_uncles)
     if calculated_uncle_root != uncles_root:
         raise ValidationError(
             f"Could not correctly encode uncles for header {header_hash.hex()}"
         )
 
     content_key = block_body_content_key(header_hash, chain_id)
-    content_value = block_body_content_value(transactions, uncles)
+    content_value = block_body_content_value(transactions, encoded_uncles)
     return content_key, content_value
 
 

--- a/eth_portal/portal_encode.py
+++ b/eth_portal/portal_encode.py
@@ -1,4 +1,3 @@
-import rlp
 import ssz
 
 from .ssz_sedes import (
@@ -36,15 +35,18 @@ def block_body_content_key(header_hash, chain_id=1):
     return BODY_TYPE_BYTE + encoded
 
 
-def block_body_content_value(transactions, uncles):
+def block_body_content_value(transactions, encoded_uncles):
     """
     Compile a list of transactions and uncle headers into a block body content value.
+
+    The uncles are already combined in a list and rlp-encoded, so they are just
+    a byte-string.
     """
     # Awkward quirk that ssz must take an iterable of individual bytes, instead of `bytes`
     encoded_transactions = [
         [bytes([byte]) for byte in transaction.encode()] for transaction in transactions
     ]
-    encoded_uncles = [[bytes([byte]) for byte in rlp.encode(uncle)] for uncle in uncles]
+    encoded_uncles = [bytes([byte]) for byte in encoded_uncles]
     return ssz.encode((encoded_transactions, encoded_uncles), BLOCK_BODY_SEDES)
 
 

--- a/eth_portal/portal_encode.py
+++ b/eth_portal/portal_encode.py
@@ -1,38 +1,13 @@
 import rlp
 import ssz
-from ssz.sedes import Byte, Container, List, Vector, uint8, uint16
 
-#
-# SSZ encoding
-#
-
-# Blocks:
-HEADER_TYPE_BYTE = b"\x00"
-BODY_TYPE_BYTE = b"\x01"
-RECEIPT_TYPE_BYTE = b"\x02"
-BLOCK_KEY_SEDES = Container(
-    (
-        uint16,  # Chain ID
-        Vector(uint8, 32),  # header hash
-    )
-)
-
-TRANSACTIONS_SEDES = List(
-    # Each encoded transaction
-    List(Byte(), 65535),  # TODO identify true upper-bound on encoded transaction length
-    65535,  # 2**16-1 transaction would use up >1.3 billion gas at 21k gas each
-)
-UNCLES_SEDES = List(
-    # Each encoded header
-    List(Byte(), 65535),  # TODO identify true upper-bound on encoded header length
-    255,  # Maximum number allowed currently is 2. 2**8-1 leaves some room for expansion
-)
-BLOCK_BODY_SEDES = Container((TRANSACTIONS_SEDES, UNCLES_SEDES))
-
-BLOCK_RECEIPTS_SEDES = List(
-    # Each encoded receipt
-    List(Byte(), 65535),  # TODO identify true upper-bound on encoded receipt length
-    65535,  # 2**16-1 receipts would use up >1.3 billion gas at 21k gas each
+from .ssz_sedes import (
+    BLOCK_BODY_SEDES,
+    BLOCK_KEY_SEDES,
+    BLOCK_RECEIPTS_SEDES,
+    BODY_TYPE_BYTE,
+    HEADER_TYPE_BYTE,
+    RECEIPT_TYPE_BYTE,
 )
 
 

--- a/eth_portal/ssz_sedes.py
+++ b/eth_portal/ssz_sedes.py
@@ -1,0 +1,60 @@
+from ssz.sedes import Byte, Container, List, Vector, uint8, uint16
+
+#
+# History Network Sedes
+#
+
+# Content Key serializations
+HEADER_TYPE_BYTE = b"\x00"
+BODY_TYPE_BYTE = b"\x01"
+RECEIPT_TYPE_BYTE = b"\x02"
+BLOCK_KEY_SEDES = Container(
+    (
+        uint16,  # Chain ID
+        Vector(uint8, 32),  # header hash
+    )
+)
+
+# Content Value serializations
+
+_MAX_TRANSACTION_LENGTH = 2**24  # ~= 16 million
+# Maximum transaction body length is achieved by filling calldata with 0's
+# until the block limit of 30M gas is reached.
+# At a gas cost of 4 per 0-byte, that produces a 7.5MB transaction. We roughly
+# double that size to a maximum of >16 million for some headroom. Note that
+# EIP-4488 would put a roughly 1MB limit on transaction length, effectively. So
+# increases are not planned (instead, the opposite).
+
+_MAX_TRANSACTION_COUNT = 2**14  # ~= 16k
+# 2**14 simple transactions would use up >340 million gas at 21k gas each.
+# Current gas limit tops out at 30 million gas.
+
+_MAX_RECEIPT_LENGTH = 2**23  # ~= 8 million
+# Maximum receipt length is logging a bunch of data out, currently at a cost of
+# 8 gas per byte. Since that is double the cost of 0 calldata bytes, the
+# maximum size is roughly half that of the transaction. That gives a maximum of
+# >8 million bytes per receipt.
+
+_MAX_HEADER_LENGTH = 2**13  # = 8192
+# Maximum header length is fairly stable at about 500 bytes. It might change at
+# the merge, and beyond. Since the length is relatively small, and the future
+# of the format is unclear to me, I'm leaving more room for expansion, and
+# setting the max at about 8 kilobytes.
+
+_TRANSACTIONS_SEDES = List(
+    # Each encoded transaction
+    List(Byte(), _MAX_TRANSACTION_LENGTH),
+    _MAX_TRANSACTION_COUNT,
+)
+_UNCLES_SEDES = List(
+    # Each encoded header
+    List(Byte(), _MAX_HEADER_LENGTH),
+    16,  # Maximum number of uncles is currently 2. 2**4 leaves some room for expansion
+)
+BLOCK_BODY_SEDES = Container((_TRANSACTIONS_SEDES, _UNCLES_SEDES))
+
+BLOCK_RECEIPTS_SEDES = List(
+    # Each encoded receipt
+    List(Byte(), _MAX_RECEIPT_LENGTH),
+    _MAX_TRANSACTION_COUNT,
+)

--- a/eth_portal/ssz_sedes.py
+++ b/eth_portal/ssz_sedes.py
@@ -41,15 +41,19 @@ _MAX_HEADER_LENGTH = 2**13  # = 8192
 # of the format is unclear to me, I'm leaving more room for expansion, and
 # setting the max at about 8 kilobytes.
 
+_MAX_ENCODED_UNCLES_LENGTH = _MAX_HEADER_LENGTH * 2**4  # = 2**17 ~= 131k
+# Maximum number of uncles is currently 2. Using 16 leaves some room for the
+# protocol to increase the number of uncles.
+
 _TRANSACTIONS_SEDES = List(
     # Each encoded transaction
     List(Byte(), _MAX_TRANSACTION_LENGTH),
     _MAX_TRANSACTION_COUNT,
 )
 _UNCLES_SEDES = List(
-    # Each encoded header
-    List(Byte(), _MAX_HEADER_LENGTH),
-    16,  # Maximum number of uncles is currently 2. 2**4 leaves some room for expansion
+    # The combined rlp-encoded list of headers
+    Byte(),
+    _MAX_ENCODED_UNCLES_LENGTH,
 )
 BLOCK_BODY_SEDES = Container((_TRANSACTIONS_SEDES, _UNCLES_SEDES))
 

--- a/tests/core/test_bridge.py
+++ b/tests/core/test_bridge.py
@@ -111,7 +111,7 @@ def test_block_body_content(web3_block_and_uncles):
         "0x010300720704f3aa11c53cf344ea069db95cecb81ad7453c8f276b2a1062979611f09c"
     )  # noqa: E501
     assert HexBytes(keccak(content_value)) == HexBytes(
-        "0xc920a1156472daadcbb73176fd97b25b0a9d1103aafe95691de0d627024d8198"
+        "0x254346e23a1bc176de3853a33e57a6fad7712b2ef1674dd7de91b639df28dbb6"
     )  # noqa: E501
 
 


### PR DESCRIPTION
## What was wrong?

SSZ limits on maximum number & size of transactions, receipts, and uncles were not well thought-out.

## How was it fixed?

I thought them out, after referring to a number of sources, especially py-evm.

Bonus: use the rlp-encoded list of uncles, as defined here:
https://github.com/ethereum/portal-network-specs/pull/152

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/1a/a4/06/1aa406d89086b2b94ad4f58a95c77ec8.jpg)
