### PR TITLE
Friendlier bridge launch

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -27,8 +27,11 @@ How to Run a Bridge Node
 Install eth-portal from source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Check out `eth-portal <https://github.com/carver/eth-portal>`_ via git, launch
-a fresh virtualenv, and install dependencies with ``pip install -e .[dev]``.
+In a fresh virtualenv, run ``pip install eth-portal`` to install.
+
+If you want to use the latest, greatest (and potentially buggiest), check out
+`eth-portal <https://github.com/carver/eth-portal>`_ via git and install
+dependencies with ``pip install -e .[dev]``.
 
 Link to a Portal Client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -76,11 +79,20 @@ Run the Bridge Launcher
 From within the virtualenv that eth-portal is installed, at the root of the
 eth-portal directory, run::
 
-    ./scripts/launch_bridge.py
+    python -m eth_portal.bridge
 
 The script will print when a new header is being pushed to the Portal clients.
 
 It's currently assumed that ``/tmp`` is available, and the ports 9000, 9001,
 etc. are available (depending on how many Portal clients you launch).
 
-This will roughly use up a full free Infura account.
+This will roughly use about 650k requests a day, at current mainnet levels.
+That requires a paid Infura account to run full-time.
+
+
+See the trin logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One way to see the logs being emitted from trin is to run trin separately. If you launch trin as advised, the bridge will notice that trin is already running, and use that instance.
+
+When running the bridge normally, it will print out the shell command that launches trin, so you can simply use that same command to launch trin manually. Then shut down the bridge and re-launch it.

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -1,0 +1,6 @@
+from .run import launch_bridge
+
+try:
+    launch_bridge()
+except KeyboardInterrupt:
+    print("Clean exit of bridge launcher")

--- a/eth_portal/bridge/handle.py
+++ b/eth_portal/bridge/handle.py
@@ -1,0 +1,32 @@
+from eth_portal.web3_decode import web3_result_to_transaction
+
+from .history import propagate_block_bodies, propagate_header, propagate_receipts
+from .insert import PortalInserter
+
+
+def handle_new_header(
+    w3, portal_inserter: PortalInserter, header_hash: bytes, chain_id=1
+):
+    """
+    Handle header hash notifications by posting all new data to Portal History Network.
+
+    This data to be propagated will at least include header, block bodies
+    (uncles & transactions), and receipts. At documentation time, only headers
+    are propagated.
+
+    :param w3: web3 access to core Ethereum content
+    :param portal_inserter: a class responsible for pushing content keys and
+        values into the network via a group of running portal clients
+    :param header_hash: the new header hash that we were notified exists on the network
+    :param chain_id: Ethereum network Chain ID that this header exists on
+    """
+    block_fields = propagate_header(w3, portal_inserter, chain_id, header_hash)
+
+    # Convert web3 transactions to py-evm transactions
+    transactions = [
+        web3_result_to_transaction(web3_transaction, block_fields.number)
+        for web3_transaction in block_fields.transactions
+    ]
+
+    propagate_block_bodies(w3, portal_inserter, chain_id, block_fields, transactions)
+    propagate_receipts(w3, portal_inserter, chain_id, block_fields, transactions)

--- a/eth_portal/bridge/insert.py
+++ b/eth_portal/bridge/insert.py
@@ -1,0 +1,46 @@
+from eth_utils import encode_hex
+
+
+class PortalInserter:
+    """
+    Track a group of Portal nodes, and simplify pushing content to them.
+
+    Eventually, it will intelligently choose which nodes to broadcast content
+    to. At documentation time, it naively pushes all content to all supplied nodes.
+    """
+
+    MAX_FIELD_DISPLAY_LENGTH = 2048
+
+    def __init__(self, web3_links):
+        """
+        Create an instance, with web3 links to the launched Portal nodes.
+        """
+        self._web3_links = web3_links
+
+    def push_history(self, content_key: bytes, content_value: bytes):
+        """
+        Push the given Portal History content out to the group of portal clients.
+        """
+        content_key_hex = encode_hex(content_key)
+        content_value_hex = encode_hex(content_value)
+
+        value_len = len(content_value_hex)
+        if value_len > self.MAX_FIELD_DISPLAY_LENGTH:
+            value_suffix = f"... ({value_len-self.MAX_FIELD_DISPLAY_LENGTH} more)"
+        else:
+            value_suffix = ""
+
+        print(
+            "Propagate new history content with key, value:",
+            content_key_hex,
+            ",",
+            content_value_hex[: self.MAX_FIELD_DISPLAY_LENGTH] + value_suffix,
+        )
+
+        # For now, just push to all inserting clients. When running more, be a
+        #   bit smarter about selecting inserters closer to the content key
+        for w3 in self._web3_links:
+            result = w3.provider.make_request(
+                "portal_historyStore", [content_key_hex, content_value_hex]
+            )
+            print("History store response:", result)

--- a/newsfragments/23.feature.rst
+++ b/newsfragments/23.feature.rst
@@ -1,0 +1,1 @@
+Now launch the bridge with ``python -m eth_portal.bridge``.

--- a/tests/core/test_bridge_history.py
+++ b/tests/core/test_bridge_history.py
@@ -4,7 +4,7 @@ from hexbytes import HexBytes
 import pytest
 from web3.datastructures import AttributeDict
 
-from eth_portal.bridge import (
+from eth_portal.bridge.history import (
     block_fields_to_content,
     encode_block_body_content,
     encode_receipts_content,


### PR DESCRIPTION
## What was wrong?

Couldn't run the bridge without checking out source. Wanted to run with: `python -m eth_portal.bridge` 

## How was it fixed?

Small refactor turned into a big refactor. Everything seems a bit more tidy now.

Updated the docs for the new approach (plus mention of running `trin` manually).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/1x9Vo_I4OYI/maxresdefault.jpg)