### PR TITLE
Release preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
-	towncrier --yes --version $(UPCOMING_VERSION)
+	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build
 	make build-docs
 	git commit -m "Compile release notes"

--- a/docs/eth_portal.bridge.rst
+++ b/docs/eth_portal.bridge.rst
@@ -1,0 +1,46 @@
+eth\_portal.bridge package
+==========================
+
+Submodules
+----------
+
+eth\_portal.bridge.handle module
+--------------------------------
+
+.. automodule:: eth_portal.bridge.handle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+eth\_portal.bridge.history module
+---------------------------------
+
+.. automodule:: eth_portal.bridge.history
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+eth\_portal.bridge.insert module
+--------------------------------
+
+.. automodule:: eth_portal.bridge.insert
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+eth\_portal.bridge.run module
+-----------------------------
+
+.. automodule:: eth_portal.bridge.run
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: eth_portal.bridge
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/eth_portal.rst
+++ b/docs/eth_portal.rst
@@ -1,21 +1,28 @@
 eth\_portal package
 ===================
 
+Subpackages
+-----------
+
+.. toctree::
+
+    eth_portal.bridge
+
 Submodules
 ----------
-
-eth\_portal.bridge module
--------------------------
-
-.. automodule:: eth_portal.bridge
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 eth\_portal.portal\_encode module
 ---------------------------------
 
 .. automodule:: eth_portal.portal_encode
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+eth\_portal.ssz\_sedes module
+-----------------------------
+
+.. automodule:: eth_portal.ssz_sedes
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,45 @@ Release Notes
 
 .. towncrier release notes start
 
+Portal Network Tools v0.1.0-beta.0 (2022-06-02)
+-----------------------------------------------
+
+Features
+~~~~~~~~
+
+- Launch the bridge with ``python -m eth_portal.bridge``. (`#23 <https://github.com/ethereum/eth-portal/issues/23>`__)
+- Add a new script to monitor new headers, with Infura. Also, add utility to encode header fields
+  into serialized RLP object. (`#1 <https://github.com/ethereum/eth-portal/issues/1>`__)
+- Encode header hash into a Portal History Network content key (`#2 <https://github.com/ethereum/eth-portal/issues/2>`__)
+- Encode header content key & value, on each new header hash.  (`#3 <https://github.com/ethereum/eth-portal/issues/3>`__)
+- Launch trin nodes with bridge, and push content to them, as new headers arrive. (`#4 <https://github.com/ethereum/eth-portal/issues/4>`__)
+- Encode the content key for block receipts (`#7 <https://github.com/ethereum/eth-portal/issues/7>`__)
+- Encode receipt values, tested against header's receipt root hash (`#8 <https://github.com/ethereum/eth-portal/issues/8>`__)
+- Encode a group of receipts to its Portal Network content value. Currently assumes that we
+  switch to using an SSZ list from the RLP list. (`#10 <https://github.com/ethereum/eth-portal/issues/10>`__)
+- Push the block's receipts out to trin nodes, after detecting a new header. (`#11 <https://github.com/ethereum/eth-portal/issues/11>`__)
+- In bridge launcher, detect if trin "injector" node is already running, then use it. One benefit is
+  being able to observe the logs on trin during bridge operation. (`#14 <https://github.com/ethereum/eth-portal/issues/14>`__)
+- Encode the content key for block bodies (`#16 <https://github.com/ethereum/eth-portal/issues/16>`__)
+- Decode a web3 transaction into a py-evm one, for encoding & hashing (`#17 <https://github.com/ethereum/eth-portal/issues/17>`__)
+- Encode uncles and transactions into a block body for Portal Network. (`#18 <https://github.com/ethereum/eth-portal/issues/18>`__)
+- Propagate block bodies on the Portal History Network. (`#19 <https://github.com/ethereum/eth-portal/issues/19>`__)
+
+
+Improved Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Add `bridge` node guide (`#4 <https://github.com/ethereum/eth-portal/issues/4>`__)
+
+
+Internal Changes - for Portal Network Tools Contributors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Add web3 dependency in order to poll for new headers, and py-evm dependency to encode headers to RLP (`#1 <https://github.com/ethereum/eth-portal/issues/1>`__)
+- Use black as the code formatter, and add to CI for enforcement. Upgrade isort to v5 for
+  compatibility. (`#12 <https://github.com/ethereum/eth-portal/issues/12>`__)
+
+
 v0.1.0-alpha.1
 --------------
 

--- a/newsfragments/1.feature.rst
+++ b/newsfragments/1.feature.rst
@@ -1,2 +1,0 @@
-Add a new script to monitor new headers, with Infura. Also, add utility to encode header fields
-into serialized RLP object.

--- a/newsfragments/1.internal.rst
+++ b/newsfragments/1.internal.rst
@@ -1,1 +1,0 @@
-Add web3 dependency in order to poll for new headers, and py-evm dependency to encode headers to RLP

--- a/newsfragments/10.feature.rst
+++ b/newsfragments/10.feature.rst
@@ -1,2 +1,0 @@
-Utility to encode a group of receipts to its Portal Network content value. Currently assumes that we
-switch to using an SSZ list from the RLP list.

--- a/newsfragments/11.feature.rst
+++ b/newsfragments/11.feature.rst
@@ -1,1 +1,0 @@
-Push the block's receipts out to trin nodes, after detecting a new header.

--- a/newsfragments/12.internal.rst
+++ b/newsfragments/12.internal.rst
@@ -1,2 +1,0 @@
-Use black as the code formatter, and add to CI for enforcement. Upgrade isort to v5 for
-compatibility.

--- a/newsfragments/14.feature.rst
+++ b/newsfragments/14.feature.rst
@@ -1,2 +1,0 @@
-In bridge launcher, detect if trin "injector" node is already running, then use it. One benefit is
-being able to observe the logs on trin during bridge operation.

--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,1 +1,0 @@
-Utility to encode the content key for block bodies

--- a/newsfragments/17.feature.rst
+++ b/newsfragments/17.feature.rst
@@ -1,1 +1,0 @@
-Utility to reformat a web3 transaction into a py-evm one, for encoding & hashing

--- a/newsfragments/18.feature.rst
+++ b/newsfragments/18.feature.rst
@@ -1,1 +1,0 @@
-Add utility to encode uncles and transactions into a block body for Portal Network.

--- a/newsfragments/19.feature.rst
+++ b/newsfragments/19.feature.rst
@@ -1,1 +1,0 @@
-Bridge node now propagates block bodies on the Portal History Network.

--- a/newsfragments/2.internal.rst
+++ b/newsfragments/2.internal.rst
@@ -1,1 +1,0 @@
-Add support for converting a header hash into a Portal History Network Content ID

--- a/newsfragments/23.feature.rst
+++ b/newsfragments/23.feature.rst
@@ -1,1 +1,0 @@
-Now launch the bridge with ``python -m eth_portal.bridge``.

--- a/newsfragments/3.feature.rst
+++ b/newsfragments/3.feature.rst
@@ -1,2 +1,0 @@
-On each header hash, build and print History Network content ID & value (another step closer to
-propagating headers as a bridge node).

--- a/newsfragments/4.doc.rst
+++ b/newsfragments/4.doc.rst
@@ -1,1 +1,0 @@
-Add `bridge` node guide

--- a/newsfragments/4.feature.rst
+++ b/newsfragments/4.feature.rst
@@ -1,1 +1,0 @@
-Launch trin nodes with bridge, and push content to them, as new headers arrive.

--- a/newsfragments/7.feature.rst
+++ b/newsfragments/7.feature.rst
@@ -1,1 +1,0 @@
-Utility to encode the content key for block receipts

--- a/newsfragments/8.feature.rst
+++ b/newsfragments/8.feature.rst
@@ -1,1 +1,0 @@
-Encode receipt values, tested against header's receipt root hash

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     'doc': [
         "Sphinx>=1.6.5,<2",
         "sphinx_rtd_theme>=0.1.9,<1",
-        "towncrier>=19.2.0, <20",
+        "towncrier>=21,<22",
         "Jinja2<3",
         "MarkupSafe<2",
     ],


### PR DESCRIPTION
## What was wrong?

Towncrier was old, with the double-title bug.
The doc index did not know about the refactor yet.
No release notes available yet.

## How was it fixed?

- Upgrade towncrier, and use the new `build` subcommand
- Delete the auto-generated docs & let make rebuild them
- Compile the release notes from towncrier, plus some manual cleanup for readability

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c8.alamy.com/comp/2CFMXP2/cute-rottweiler-puppy-dog-sniffing-a-broom-in-garden-2CFMXP2.jpg)