### PR TITLE
Use portal_historyOffer to propagate (instead of _historyStore)

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -10,7 +10,7 @@ node.
 
 It starts by monitoring the Ethereum network and storing newfound data into a
 Portal client that has joined the network, using a Portal-specific json-rpc API,
-like ``portal_historyStore``. See the full `Portal RPC API
+like ``portal_historyOffer``. See the full `Portal RPC API
 <https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false>`_.
 
 When to Run a Bridge Node

--- a/eth_portal/bridge/insert.py
+++ b/eth_portal/bridge/insert.py
@@ -41,7 +41,7 @@ class PortalInserter:
         #   bit smarter about selecting inserters closer to the content key
         for w3 in self._web3_links:
             result = w3.provider.make_request(
-                "portal_historyStore", [content_key_hex, content_value_hex]
+                "portal_historyOffer", [content_key_hex, content_value_hex]
             )
             node_id = _w3_ipc_to_id(w3)
             print("Sending history item to", node_id, "response:", result)

--- a/newsfragments/27.breaking.rst
+++ b/newsfragments/27.breaking.rst
@@ -1,0 +1,3 @@
+Use the portal_historyOffer rpc endpoint of trin, instead of portal_historyStore. This requires a
+more recent version of trin. Follow the `rpc update in trin
+<https://github.com/ethereum/trin/pull/411>`_ for more.


### PR DESCRIPTION
## What was wrong?

`trin` was updated so that `portal_historyStore` no longer propagates the data (it only stores it to disk). The offer RPC endpoint was updated to offer to all connected peers (and to accept the content value, rather than assume the content was already in the node).

## How was it fixed?

Use `portal_historyOffer` instead. Plus a bunch of bonus logging and recovery (like when the filter gets lost).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)
- [x] Confirm that `portal_historyOffer` is the final RPC endpoint name to be used by `trin` and other clients (See: https://github.com/ethereum/trin/pull/411 )

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://en.bcdn.biz/Images/2018/12/24/c009c256-341c-4de1-9383-4d0e303e45aa.jpg)
