### PR TITLE
Inject prebuilt Portal content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ common: &common
         when: on_fail
     - restore_cache:
         keys:
-          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-v2
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -33,7 +33,7 @@ common: &common
           - ~/.cache/pip
           - ~/.local
           - ./eggs
-        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-v2
 
 jobs:
   docs:

--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -154,3 +154,34 @@ trin is already running, and use that instance.
 In order to determine the correct trin command, you can inspect the shell
 output at the beginning of launching the bridge. Then shut down the bridge, use
 the printed command to launch trin, and re-launch the bridge.
+
+
+Inject Content Manually
+-------------------------
+
+The standard bridge node pushes all new network data in. Sometimes we want to
+push in old data. To do so, read on.
+
+If you have never run the bridge before, see `First Installation`_
+(although you can skip the Infura setup).
+
+Next, generate Portal-valid content keys and values. Load them into files,
+formatted according to these rules:
+
+- Each item of content is represented in its own file
+- Files have the ``.portalcontent`` extension
+- Files are named with the hex-encoded content key before the ``.``
+- File contents are the binary-encoded value to insert
+
+Supply the paths to these content files using the bridge node CLI, like::
+
+    python -m eth_portal.bridge mycontentfiles/*.portalcontent
+
+This is simply a regular path glob argument. So if you want to load every file
+in a folder, then this works too::
+
+    python -m eth_portal.bridge mycontentfiles/*
+
+By passing in an argument to the bridge command, you indicate that you want to
+inject the specified content, and then shut down. The bridge will not try to
+insert any content besides what you specify here.

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -1,6 +1,13 @@
+import sys
+
 from .run import launch_bridge
 
+content_files = sys.argv[1:]
 try:
-    launch_bridge()
+    # if any content files are supplied, inject those instead of following the chain head
+    launch_bridge(content_files)
 except KeyboardInterrupt:
-    print("Clean exit of bridge launcher")
+    if len(content_files):
+        print("Warning: process exited before pushing out all content")
+    else:
+        print("Clean exit of bridge launcher")

--- a/eth_portal/bridge/inject.py
+++ b/eth_portal/bridge/inject.py
@@ -1,0 +1,39 @@
+import binascii
+from pathlib import Path
+
+from eth_utils import ValidationError, to_bytes, to_tuple
+
+# TODO make issue to supply directories in addition to files
+
+
+@to_tuple
+def parse_content_keys(content_files):
+    for str_path in content_files:
+        path = Path(str_path)
+        if not path.exists():
+            raise ValidationError(f"Supplied file {path!r} does not exist")
+        if not path.is_file():
+            raise ValidationError(
+                f"Supplied path {path!r} does not point to a file (is it a directory?)"
+            )
+        if path.suffix != ".portalcontent":
+            raise ValidationError(
+                f"Supplied files must end in .portalcontent, unlike: {path!r}"
+            )
+        try:
+            content_key = to_bytes(hexstr=path.stem)
+        except binascii.Error:
+            raise ValidationError(
+                f"File names must be in a hex-encoded format, unlike: {path!r}"
+            )
+
+        yield content_key, path
+
+
+def inject_content(portal_inserter, content_files):
+    parsed_paths = parse_content_keys(content_files)
+
+    print(f"Injecting {len(parsed_paths)} items of content...")
+    for content_key, path in parsed_paths:
+        content_value = path.read_bytes()
+        portal_inserter.push_history(content_key, content_value)

--- a/eth_portal/bridge/inject.py
+++ b/eth_portal/bridge/inject.py
@@ -1,8 +1,11 @@
 import binascii
 from pathlib import Path
+import time
 
 from eth_utils import ValidationError, to_bytes, to_tuple
 
+MINIMUM_OTHER_PEERS_OFFERED = 3
+SECONDS_TO_FIND_MORE_PEERS = 10
 # TODO make issue to supply directories in addition to files
 
 
@@ -30,10 +33,41 @@ def parse_content_keys(content_files):
         yield content_key, path
 
 
+@to_tuple
+def attempt_inject_all(portal_inserter, parsed_paths):
+    """
+    Inject all the content items, returning any that do not offer to enough peers.
+
+    Note that trin is currently returning the number of peers offered (not
+    accepted), and ignores whether that content was previously offered. So on
+    multiple attempts to call this method, the result can be considered a
+    cumulative count of how many peers were offered.
+
+    This method returns if the *most connected* bridge client doesn't offer to
+    enough peers. It ignores any lesser-connected bridge clients, which may be
+    offering to duplicate peers of the most-connected client.
+
+    :param content_paths: a list of (content_key, Path) content items to inject to network
+
+    :return: a tuple of content_paths that too few peers were interested in
+    """
+    print(f"Injecting {len(parsed_paths)} items")
+    for content_key, path in parsed_paths:
+        content_value = path.read_bytes()
+        peer_offers = portal_inserter.push_history(content_key, content_value)
+        if max(peer_offers) < MINIMUM_OTHER_PEERS_OFFERED:
+            yield content_key, path
+
+
 def inject_content(portal_inserter, content_files):
     parsed_paths = parse_content_keys(content_files)
 
-    print(f"Injecting {len(parsed_paths)} items of content...")
-    for content_key, path in parsed_paths:
-        content_value = path.read_bytes()
-        portal_inserter.push_history(content_key, content_value)
+    failed_paths = attempt_inject_all(portal_inserter, parsed_paths)
+
+    while len(failed_paths):
+        print(f"Too few peers were interested in {len(failed_paths)} items")
+        print(f"Retrying in {SECONDS_TO_FIND_MORE_PEERS} seconds...")
+        time.sleep(SECONDS_TO_FIND_MORE_PEERS)
+        failed_paths = attempt_inject_all(portal_inserter, failed_paths)
+
+    print(f"Successfully injected all {len(parsed_paths)} content items")

--- a/eth_portal/bridge/insert.py
+++ b/eth_portal/bridge/insert.py
@@ -1,6 +1,15 @@
 import time
 
-from eth_utils import encode_hex
+from eth_utils import encode_hex, to_tuple
+
+
+# TODO: add a portal formatter to upstream Web3 and then delete this method
+def _parse_number_clients_contacted(response):
+    if "result" in response:
+        return response["result"]
+    else:
+        print("json response to history offer was an error: {json_response!r}")
+        return 0
 
 
 class PortalInserter:
@@ -19,9 +28,13 @@ class PortalInserter:
         """
         self._web3_links = web3_links
 
+    @to_tuple
     def push_history(self, content_key: bytes, content_value: bytes):
         """
         Push the given Portal History content out to the group of portal clients.
+
+        :return: a list of how many peers were contacted with the content, with
+            an entry for each local client that the history was pushed to.
         """
         content_key_hex = encode_hex(content_key)
         content_value_hex = encode_hex(content_value)
@@ -45,6 +58,7 @@ class PortalInserter:
             result = self.offer_hex_content(w3, content_key_hex, content_value_hex)
             node_id = _w3_ipc_to_id(w3)
             print("Sent history item to", node_id, "response:", result)
+            yield _parse_number_clients_contacted(result)
 
     @staticmethod
     def offer_hex_content(w3, key, val):

--- a/eth_portal/trin.py
+++ b/eth_portal/trin.py
@@ -34,7 +34,7 @@ def launch_trin(private_key: bytes, port: int):
         "--discovery-port", str(port),
         "--unsafe-private-key", private_key_hex,
         "--web3-ipc-path", ipc_path,
-        "--kb", "20000",
+        "--kb", "0",
         "--networks", "history",
         "--bootnodes", "default",
         # fmt: on

--- a/newsfragments/35.feature.rst
+++ b/newsfragments/35.feature.rst
@@ -1,0 +1,1 @@
+Add the ability to inject specific content items on-demand. See `Inject Content Manually`_


### PR DESCRIPTION
## What was wrong?

Fix #35 

## How was it fixed?

Read the file names as hex-encoded content keys, and the file contents as the binary content values. Push them to all the launched trin clients. If too few (interested) peers are connected, keep retrying.

Bonus:
- Sometimes if we try to use web3 too fast, trin won't be fully loaded yet. Retry every 100ms, giving up after 10s.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Write the docs
- [x] If none of the clients have any peers that are interested, pause and retry in a little while

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/11/BRlE-Uog3Lj-1-png__700.jpg)