### PR TITLE
Inject at header

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -55,7 +55,7 @@ Use this bash code to launch the bridge for the very first time::
   [ "$PORTAL_BRIDGE_KEYS" ] || echo "Missing Portal Bridge Keys!"
 
   # Launch the bridge node
-  python -m eth_portal.bridge
+  python -m eth_portal.bridge --latest
 
 .. note::
   Look for the ALL_CAPS variables that you must provide ahead of time with
@@ -73,7 +73,7 @@ with::
   . eth-portal-venv/bin/activate
 
   # Launch the bridge node
-  python -m eth_portal.bridge
+  python -m eth_portal.bridge --latest
 
 You can find more detail about these steps in the sections below.
 
@@ -131,7 +131,7 @@ Detail on Launching the Bridge
 
 If you have any trouble launching the bridge::
 
-    python -m eth_portal.bridge
+    python -m eth_portal.bridge --latest
 
 Then first make sure that you have activated your virtualenv, and are in the
 originally installed directory. There should be a ``trin`` binary linked there.
@@ -175,12 +175,12 @@ formatted according to these rules:
 
 Supply the paths to these content files using the bridge node CLI, like::
 
-    python -m eth_portal.bridge mycontentfiles/*.portalcontent
+    python -m eth_portal.bridge --content-files mycontentfiles/*.portalcontent
 
 This is simply a regular path glob argument. So if you want to load every file
 in a folder, then this works too::
 
-    python -m eth_portal.bridge mycontentfiles/*
+    python -m eth_portal.bridge --content-files mycontentfiles/*
 
 By passing in an argument to the bridge command, you indicate that you want to
 inject the specified content, and then shut down. The bridge will not try to

--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -156,11 +156,31 @@ output at the beginning of launching the bridge. Then shut down the bridge, use
 the printed command to launch trin, and re-launch the bridge.
 
 
+Backfill historical blocks
+---------------------------
+
+The standard bridge node pushes all new network data in. Sometimes we want to
+push in a particular block range. To do so, read on.
+
+If you have never run the bridge before, see `First Installation`_.
+
+In order to import blocks numbered 100 through 200 (ie~ including 100 and 200),
+run this command::
+
+    python -m eth_portal.bridge --block-range 100 200
+
+To import a single block, just repeat the same block number twice.
+
+This command will publish the specified blocks, and then shut down. The bridge
+will not try to insert any content besides what you specify here.
+
+
 Inject Content Manually
 -------------------------
 
-The standard bridge node pushes all new network data in. Sometimes we want to
-push in old data. To do so, read on.
+The standard bridge node determines the latest data to push in by following the
+chain. Sometimes we want to locally generate the data and publish it. To do so,
+read on.
 
 If you have never run the bridge before, see `First Installation`_
 (although you can skip the Infura setup).

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -1,13 +1,35 @@
-import sys
+from argparse import ArgumentParser
 
-from .run import launch_bridge
+from .run import launch_bridge, launch_injector
 
-content_files = sys.argv[1:]
+# Parse CLI arguments
+parser = ArgumentParser()
+group = parser.add_mutually_exclusive_group()
+group.add_argument(
+    "-l",
+    "--latest",
+    action="store_true",
+    help="Track the head of the chain, and publish the latest content into the Portal network.",
+)
+group.add_argument(
+    "-f",
+    "--content-files",
+    nargs="+",
+    help="Load the content from the files, and publish them into the Portal network.",
+)
+args = parser.parse_args()
+
 try:
-    # if any content files are supplied, inject those instead of following the chain head
-    launch_bridge(content_files)
+    if args.latest:
+        launch_bridge()
+    elif args.content_files:
+        launch_injector(args.content_files)
+    else:
+        raise RuntimeError("Must run bridge with an option. Run with -h to see them.")
 except KeyboardInterrupt:
-    if len(content_files):
+    if args.latest:
+        print("Clean exit of bridge launcher")
+    elif args.content_files:
         print("Warning: process exited before pushing out all content")
     else:
-        print("Clean exit of bridge launcher")
+        raise RuntimeError("Program ended early, with unknown command line argument")

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 
-from .run import launch_bridge, launch_injector
+from .run import launch_backfill, launch_bridge, launch_injector
 
 # Parse CLI arguments
 parser = ArgumentParser()
@@ -17,6 +17,16 @@ group.add_argument(
     nargs="+",
     help="Load the content from the files, and publish them into the Portal network.",
 )
+group.add_argument(
+    "-b",
+    "--block-range",
+    nargs=2,
+    type=int,
+    help=(
+        "Load the blocks from the start number to the end number given (inclusive),"
+        " and publish them into the Portal network."
+    ),
+)
 args = parser.parse_args()
 
 try:
@@ -24,12 +34,20 @@ try:
         launch_bridge()
     elif args.content_files:
         launch_injector(args.content_files)
+    elif args.block_range:
+        start, end = args.block_range
+        if start > end:
+            raise RuntimeError(
+                "The end block must be the same or larger than the start block"
+            )
+        else:
+            launch_backfill(start, end)
     else:
         raise RuntimeError("Must run bridge with an option. Run with -h to see them.")
 except KeyboardInterrupt:
     if args.latest:
         print("Clean exit of bridge launcher")
-    elif args.content_files:
+    elif args.content_files or args.block_range:
         print("Warning: process exited before pushing out all content")
     else:
         raise RuntimeError("Program ended early, with unknown command line argument")

--- a/eth_portal/bridge/handle.py
+++ b/eth_portal/bridge/handle.py
@@ -1,6 +1,4 @@
-from eth_portal.web3_decode import web3_result_to_transaction
-
-from .history import propagate_block_bodies, propagate_header, propagate_receipts
+from .history import propagate_block
 from .insert import PortalInserter
 
 
@@ -20,13 +18,7 @@ def handle_new_header(
     :param header_hash: the new header hash that we were notified exists on the network
     :param chain_id: Ethereum network Chain ID that this header exists on
     """
-    block_fields = propagate_header(w3, portal_inserter, chain_id, header_hash)
+    # Retrieve data to post to network
+    block_fields = w3.eth.get_block(header_hash, full_transactions=True)
 
-    # Convert web3 transactions to py-evm transactions
-    transactions = [
-        web3_result_to_transaction(web3_transaction, block_fields.number)
-        for web3_transaction in block_fields.transactions
-    ]
-
-    propagate_block_bodies(w3, portal_inserter, chain_id, block_fields, transactions)
-    propagate_receipts(w3, portal_inserter, chain_id, block_fields, transactions)
+    propagate_block(w3, portal_inserter, block_fields, chain_id)

--- a/eth_portal/bridge/run.py
+++ b/eth_portal/bridge/run.py
@@ -53,15 +53,18 @@ def poll_chain_head(portal_inserter):
             continue
 
 
-def launch_bridge(content_files):
+def launch_bridge():
     # Launch trin nodes, for broadcasting data
     # The context manager shuts down all trin nodes on context exit
     trin_node_keys = load_private_keys()
     with launch_trin_inserters(trin_node_keys) as portal_inserter:
-        if len(content_files):
-            inject_content(portal_inserter, content_files)
-        else:
-            poll_chain_head(portal_inserter)
+        poll_chain_head(portal_inserter)
+
+
+def launch_injector(content_files):
+    trin_node_keys = load_private_keys()
+    with launch_trin_inserters(trin_node_keys) as portal_inserter:
+        inject_content(portal_inserter, content_files)
 
 
 @contextmanager

--- a/newsfragments/34.feature.rst
+++ b/newsfragments/34.feature.rst
@@ -1,0 +1,1 @@
+Publish data from a historical block range with ``--block-range``. See `Backfill historical blocks`_

--- a/newsfragments/38.breaking.rst
+++ b/newsfragments/38.breaking.rst
@@ -1,0 +1,2 @@
+In order to follow the tip of the chain, you must now specify ``--latest`` or ``-l``.
+See `Run after first installation`_


### PR DESCRIPTION
## What was wrong?

FIx #34 

## How was it fixed?

Change the CLI structure so that you specify a particular command (eg~ `--latest` to track the head of the chain, or `--content-files` to inject prebuilt content).

Add a new `--block-range` flag that lets you specify a historical block range to publish data for.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Add section to docs for specifying a block range

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.istockphoto.com/photos/sleepy-brown-cute-chihuahua-dog-on-table-with-heap-of-wooden-block-picture-id918632454?k=20&m=918632454&s=170667a&w=0&h=Z-rt8pxH3les6E2YJV0uAOvy9lpCmNMFuYe89DyqJmE=)