### PR TITLE
Save invalid receipts to a tempfile for analysis

### DIFF
--- a/newsfragments/32.internal.rst
+++ b/newsfragments/32.internal.rst
@@ -1,0 +1,2 @@
+When receipts fail their check against the expected root hash, save them to a file in a temporary
+directory


### PR DESCRIPTION
Hex-encoded to make it easy to mark the end of each receipt with a newline.

## What was wrong?

Fix #32 

## How was it fixed?

Save bad receipts to a temporary file. Write the file name to the output.

When choosing how to encode the receipts to file, there were some options:

1. binary encoding of receipt, with either
  1. one receipt per file, OR
  2. all in one file, depends on RLP to figure out where the end of each receipt is
2. hex encoding with newlines to separate receipts
3. some other encoding (eg~ base64) with newlines to separate

1.1 seems to introduce too many little files
1.2 is problematic if we have malformed RLP to tell which one is malformed
2. I chose this option as easy. Hex is often the format that encoded binary data is displayed in, so it may be a little more familiar to readers, even if it doubles the size of the file, from binary
3. Might include some file size savings, but at the cost of: making an encoding choice, and unfamiliarity from the readers

I was hoping that #38 would solve 32 by letting us replay the block numbers. But that block number seems to run fine when I run it on my machine. So the saved data would actually be useful for analysis.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.costarica.com/contentAsset/image/c97d353d-d70e-4fbc-8842-a051f9a874ba/fileAsset/filter/Resize,Jpeg/resize_w/600/Jpeg_q/.8/)
