### PR TITLE
Update max receipt length constant

### DIFF
--- a/eth_portal/ssz_sedes.py
+++ b/eth_portal/ssz_sedes.py
@@ -29,11 +29,13 @@ _MAX_TRANSACTION_COUNT = 2**14  # ~= 16k
 # 2**14 simple transactions would use up >340 million gas at 21k gas each.
 # Current gas limit tops out at 30 million gas.
 
-_MAX_RECEIPT_LENGTH = 2**23  # ~= 8 million
+_MAX_RECEIPT_LENGTH = 2**27  # ~= 134 million
 # Maximum receipt length is logging a bunch of data out, currently at a cost of
 # 8 gas per byte. Since that is double the cost of 0 calldata bytes, the
-# maximum size is roughly half that of the transaction. That gives a maximum of
-# >8 million bytes per receipt.
+# maximum size is roughly half that of the transaction: 3.75 million bytes.
+# But there is more reason for protocol devs to constrain the transaction length,
+# and it's not clear what the practical limits for receipts are, so we should add more buffer room.
+# Imagine the cost drops by 2x and the block gas limit goes up by 8x. So we add 2**4 = 16x buffer.
 
 _MAX_HEADER_LENGTH = 2**13  # = 8192
 # Maximum header length is fairly stable at about 500 bytes. It might change at


### PR DESCRIPTION
## What was wrong?
For some reason, we're having trouble decoding ssz-encoded block bodies generated by ultralight. This doesn't seem to solve the problem, but I noticed it was not up-to-date with the [spec](https://github.com/ethereum/portal-network-specs/blob/254aecd3c946e11c73423932af3195d2cd8a4eb2/history-network.md#constants). 

## How was it fixed?

Updated constant value & docs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/191821998-01d4249a-8c01-4e35-8624-0ec2b280f5c0.png)
