### PR TITLE
Docs absolute link path

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -101,7 +101,7 @@ the root of the eth-portal source directory.
 For example, if trin is checked out in a sibling directory to eth-portal, you
 could run this from the parent directory of both::
 
-    ln -s trin/target/debug/trin eth-portal/trin
+    ln -s "$PWD/trin/target/debug/trin" eth-portal/trin
 
 Detail on Linking to Infura
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/newsfragments/40.bugfix.rst
+++ b/newsfragments/40.bugfix.rst
@@ -1,0 +1,1 @@
+Correct the maximum receipt length in SSZ encoding. No specific known bug is fixed by this change.

--- a/newsfragments/42.doc.rst
+++ b/newsfragments/42.doc.rst
@@ -1,0 +1,3 @@
+Update ``ln -s`` example in bridge setup guide to use absolute source path. This prevents folks from
+getting a ``Too many levels of symbolic links`` error during setup, because `soft links require an
+absolute source path <https://unix.stackexchange.com/a/180532/251234>`_.


### PR DESCRIPTION
## What was wrong?

@njgheorghita mentioned that the `ln -s` example was broken because it used a relative path for the source path.

## How was it fixed?

Specify an absolute path using a bash variable, since we as guide-writers don't know the actual absolute path of the trin binary.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://scubadiverlife.com/wp-content/uploads/2017/07/cutest_puffer.jpeg)