### PR TITLE
Remove chain id from content key schema

### DIFF
--- a/eth_portal/bridge/handle.py
+++ b/eth_portal/bridge/handle.py
@@ -2,9 +2,7 @@ from .history import propagate_block
 from .insert import PortalInserter
 
 
-def handle_new_header(
-    w3, portal_inserter: PortalInserter, header_hash: bytes, chain_id=1
-):
+def handle_new_header(w3, portal_inserter: PortalInserter, header_hash: bytes):
     """
     Handle header hash notifications by posting all new data to Portal History Network.
 
@@ -16,9 +14,8 @@ def handle_new_header(
     :param portal_inserter: a class responsible for pushing content keys and
         values into the network via a group of running portal clients
     :param header_hash: the new header hash that we were notified exists on the network
-    :param chain_id: Ethereum network Chain ID that this header exists on
     """
     # Retrieve data to post to network
     block_fields = w3.eth.get_block(header_hash, full_transactions=True)
 
-    propagate_block(w3, portal_inserter, block_fields, chain_id)
+    propagate_block(w3, portal_inserter, block_fields)

--- a/eth_portal/portal_encode.py
+++ b/eth_portal/portal_encode.py
@@ -10,28 +10,24 @@ from .ssz_sedes import (
 )
 
 
-def header_content_key(header_hash, chain_id=1):
+def header_content_key(header_hash):
     """
     Convert a header hash into a header content key for the Portal History Network.
-
-    Include the chain ID, which defaults to mainnet.
     """
     # The header type ID is implicitly defined in the SSZ union which
     # specifies the content key on the header history network.
-    encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
+    encoded = ssz.encode((header_hash,), BLOCK_KEY_SEDES)
 
     # I don't think py-ssz supports Union types, so manually tacking it on
     return HEADER_TYPE_BYTE + encoded
 
 
-def block_body_content_key(header_hash, chain_id=1):
+def block_body_content_key(header_hash):
     """
     Convert a header hash into a block body content key for the Portal History Network.
-
-    Include the chain ID, which defaults to mainnet.
     """
     # See implementation notes in header_content_key()
-    encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
+    encoded = ssz.encode((header_hash,), BLOCK_KEY_SEDES)
     return BODY_TYPE_BYTE + encoded
 
 
@@ -46,14 +42,12 @@ def block_body_content_value(transactions, encoded_uncles):
     return ssz.encode((encoded_transactions, encoded_uncles), BLOCK_BODY_SEDES)
 
 
-def receipt_content_key(header_hash, chain_id=1):
+def receipt_content_key(header_hash):
     """
     Convert a header hash into a receipt content key for the Portal History Network.
-
-    Include the chain ID, which defaults to mainnet.
     """
     # See implementation notes in header_content_key()
-    encoded = ssz.encode((chain_id, header_hash), BLOCK_KEY_SEDES)
+    encoded = ssz.encode((header_hash,), BLOCK_KEY_SEDES)
     return RECEIPT_TYPE_BYTE + encoded
 
 

--- a/eth_portal/ssz_sedes.py
+++ b/eth_portal/ssz_sedes.py
@@ -1,4 +1,4 @@
-from ssz.sedes import ByteList, Container, List, Vector, uint8, uint16
+from ssz.sedes import ByteList, Container, List, Vector, uint8
 
 #
 # History Network Sedes
@@ -8,12 +8,7 @@ from ssz.sedes import ByteList, Container, List, Vector, uint8, uint16
 HEADER_TYPE_BYTE = b"\x00"
 BODY_TYPE_BYTE = b"\x01"
 RECEIPT_TYPE_BYTE = b"\x02"
-BLOCK_KEY_SEDES = Container(
-    (
-        uint16,  # Chain ID
-        Vector(uint8, 32),  # header hash
-    )
-)
+BLOCK_KEY_SEDES = Container((Vector(uint8, 32),))  # header hash
 
 # Content Value serializations
 

--- a/newsfragments/44.bugfix.rst
+++ b/newsfragments/44.bugfix.rst
@@ -1,0 +1,1 @@
+Updated content key encoding ssz scheme & test vectors to new spec, removing the chain id.

--- a/tests/core/test_portal_encode.py
+++ b/tests/core/test_portal_encode.py
@@ -9,66 +9,63 @@ from eth_portal.portal_encode import (
 
 
 @pytest.mark.parametrize(
-    "chain_id, header_hash, expected_encoding",
+    "header_hash, expected_encoding",
     (
-        (2, b"H" * 32, b"\x00\x02\x00" + b"H" * 32),
+        (b"H" * 32, b"\x00" + b"H" * 32),
         (
             # Pulled test data from:
             # https://github.com/ethereum/portal-network-specs/blob/2fb0116314c407feff4ce678dac2da5adea834eb/content-keys-test-vectors.md#headerkey
-            15,
             decode_hex(
                 "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
             decode_hex(
-                "0x000f00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+                "0x00d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
         ),
     ),
 )
-def test_encode_header_key(chain_id, header_hash, expected_encoding):
-    content_key = header_content_key(header_hash, chain_id)
+def test_encode_header_key(header_hash, expected_encoding):
+    content_key = header_content_key(header_hash)
     assert content_key == expected_encoding
 
 
 @pytest.mark.parametrize(
-    "chain_id, header_hash, expected_encoding",
+    "header_hash, expected_encoding",
     (
-        (2, b"H" * 32, b"\x01\x02\x00" + b"H" * 32),
+        (b"H" * 32, b"\x01" + b"H" * 32),
         (
             # Pulled test data from:
             # https://github.com/ethereum/portal-network-specs/blob/b75886b1b4287291d1967974a97f914d91618167/content-keys-test-vectors.md#bodykey
-            20,
             decode_hex(
                 "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
             decode_hex(
-                "0x011400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+                "0x01d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
         ),
     ),
 )
-def test_encode_block_body_key(chain_id, header_hash, expected_encoding):
-    content_key = block_body_content_key(header_hash, chain_id)
+def test_encode_block_body_key(header_hash, expected_encoding):
+    content_key = block_body_content_key(header_hash)
     assert content_key == expected_encoding
 
 
 @pytest.mark.parametrize(
-    "chain_id, header_hash, expected_encoding",
+    "header_hash, expected_encoding",
     (
-        (2, b"H" * 32, b"\x02\x02\x00" + b"H" * 32),
+        (b"H" * 32, b"\x02" + b"H" * 32),
         (
             # Pulled test data from:
             # https://github.com/ethereum/portal-network-specs/blob/2fb0116314c407feff4ce678dac2da5adea834eb/content-keys-test-vectors.md#receiptskey
-            4,
             decode_hex(
                 "0xd1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
             decode_hex(
-                "0x020400d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
+                "0x02d1c390624d3bd4e409a61a858e5dcc5517729a9170d014a6c96530d64dd8621d"
             ),
         ),
     ),
 )
-def test_encode_receipt_key(chain_id, header_hash, expected_encoding):
-    content_key = receipt_content_key(header_hash, chain_id)
+def test_encode_receipt_key(header_hash, expected_encoding):
+    content_key = receipt_content_key(header_hash)
     assert content_key == expected_encoding


### PR DESCRIPTION
## What was wrong?
In the latest spec update, we've removed the chain id from content key encoding.

Issue #

## How was it fixed?

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/193653337-a1b6a360-2aee-4fd5-880a-beb234de3984.png)
