### PR TITLE
Enable custom authenticated provider

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -125,6 +125,19 @@ After selecting your private keys, concatenate them using commas and add it to y
 
     export PORTAL_BRIDGE_KEYS=7261696e626f77737261696e626f77737261696e626f77737261696e626f7773,756e69636f726e73756e69636f726e73756e69636f726e73756e69636f726e73
 
+Detail on using a custom authenticated provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The bridge uses Infura as its default Web3 provider, but supports a custom, authenticated provider.
+The following three environment variables must be set to use a custom provider.
+- `AUTH_CLIENT_URL`
+- `AUTH_CLIENT_ID`
+- `AUTH_CLIENT_SECRET`
+
+To use a custom provider, pass in the following flag when launching the bridge::
+
+    python -m eth_portal.bridge --latest -p custom 
+
 
 Detail on Launching the Bridge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -125,18 +125,18 @@ After selecting your private keys, concatenate them using commas and add it to y
 
     export PORTAL_BRIDGE_KEYS=7261696e626f77737261696e626f77737261696e626f77737261696e626f7773,756e69636f726e73756e69636f726e73756e69636f726e73756e69636f726e73
 
-Detail on using a custom authenticated provider
+Detail on using a cloudflare authenticated provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The bridge uses Infura as its default Web3 provider, but supports a custom, authenticated provider.
-The following three environment variables must be set to use a custom provider.
+The bridge uses Infura as its default Web3 provider, but supports a authenticated, cloudflare provider.
+The following three environment variables must be set to use an authenticated, cloudflare provider.
 - `AUTH_CLIENT_URL`
 - `AUTH_CLIENT_ID`
 - `AUTH_CLIENT_SECRET`
 
-To use a custom provider, pass in the following flag when launching the bridge::
+To use an authenticated cloudflare provider, pass in the following flag when launching the bridge::
 
-    python -m eth_portal.bridge --latest -p custom 
+    python -m eth_portal.bridge --latest -p cloudflare-auth
 
 
 Detail on Launching the Bridge

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -27,11 +27,18 @@ group.add_argument(
         " and publish them into the Portal network."
     ),
 )
+parser.add_argument(
+    "-p",
+    "--provider",
+    choices=["infura", "custom"],
+    default="infura",
+    help="What kind of provider to use. Defaults to Infura.",
+)
 args = parser.parse_args()
 
 try:
     if args.latest:
-        launch_bridge()
+        launch_bridge(args.provider)
     elif args.content_files:
         launch_injector(args.content_files)
     elif args.block_range:
@@ -41,7 +48,7 @@ try:
                 "The end block must be the same or larger than the start block"
             )
         else:
-            launch_backfill(start, end)
+            launch_backfill(start, end, args.provider)
     else:
         raise RuntimeError("Must run bridge with an option. Run with -h to see them.")
 except KeyboardInterrupt:

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -30,7 +30,7 @@ group.add_argument(
 parser.add_argument(
     "-p",
     "--provider",
-    choices=["infura", "custom"],
+    choices=["infura", "cloudflare-auth"],
     default="infura",
     help="What kind of provider to use. Defaults to Infura.",
 )

--- a/eth_portal/bridge/run.py
+++ b/eth_portal/bridge/run.py
@@ -18,9 +18,9 @@ INVALID_KEY_ENV_ERROR = (
     " comma-separated list of hex-encoded Portal client 32-byte private keys"
 )
 
-INVALID_AUTH_PROVIDER_ENV_ERROR = (
+INVALID_CLOUDFLARE_AUTH_PROVIDER_ENV_ERROR = (
     "Must supply the following environment variables to use an authenticated"
-    "provider: \nAUTH_CLIENT_ID, AUTH_CLIENT_SECRET, AUTH_CLIENT_URL"
+    "cloudflare provider: \nAUTH_CLIENT_ID, AUTH_CLIENT_SECRET, AUTH_CLIENT_URL"
 )
 
 
@@ -127,13 +127,13 @@ def load_private_keys():
 
 
 def load_provider(provider_arg):
-    if provider_arg == "custom":
+    if provider_arg == "cloudflare-auth":
         try:
             client_id = os.environ["AUTH_CLIENT_ID"]
             client_secret = os.environ["AUTH_CLIENT_SECRET"]
             client_url = os.environ["AUTH_CLIENT_URL"]
         except KeyError:
-            sys.exit(INVALID_AUTH_PROVIDER_ENV_ERROR)
+            sys.exit(INVALID_CLOUDFLARE_AUTH_PROVIDER_ENV_ERROR)
         headers = {
             "headers": {
                 "Content-Type": "application/json",
@@ -144,8 +144,9 @@ def load_provider(provider_arg):
         w3 = Web3(Web3.HTTPProvider(client_url, request_kwargs=headers))
         if not w3.isConnected():
             raise RuntimeError(
-                "Invalid authenticated provider credentials, provider is not connected."
+                "Invalid authenticated cloudflare provider credentials, provider is not connected."
             )
+        return w3
     else:
         from web3.auto.infura import w3
 

--- a/eth_portal/bridge/run.py
+++ b/eth_portal/bridge/run.py
@@ -6,6 +6,7 @@ import time
 from typing import Iterable
 
 from eth_utils import decode_hex
+from web3 import Web3
 
 from eth_portal.bridge.handle import handle_new_header, propagate_block
 from eth_portal.bridge.inject import inject_content
@@ -15,6 +16,11 @@ from eth_portal.trin import launch_trin
 INVALID_KEY_ENV_ERROR = (
     "Must supply environment variable PORTAL_BRIDGE_KEYS, as a"
     " comma-separated list of hex-encoded Portal client 32-byte private keys"
+)
+
+INVALID_AUTH_PROVIDER_ENV_ERROR = (
+    "Must supply the following environment variables to use an authenticated"
+    "provider: \nAUTH_CLIENT_ID, AUTH_CLIENT_SECRET, AUTH_CLIENT_URL"
 )
 
 
@@ -36,12 +42,10 @@ def header_log_loop(w3, portal_inserter, event_filter, poll_interval):
         time.sleep(poll_interval)
 
 
-def poll_chain_head(portal_inserter):
+def poll_chain_head(portal_inserter, w3):
     """
     Monitor the head of the chain, and insert new content until Ctrl-C is pressed.
     """
-    from web3.auto.infura import w3
-
     while True:
         block_filter = w3.eth.filter("latest")
 
@@ -53,9 +57,7 @@ def poll_chain_head(portal_inserter):
             continue
 
 
-def backfill_bridge_blocks(portal_inserter, start_block, end_block):
-    from web3.auto.infura import w3
-
+def backfill_bridge_blocks(portal_inserter, start_block, end_block, w3):
     block_numbers = range(start_block, end_block + 1)
     print(f"Injecting {len(block_numbers)} blocks, starting from #{start_block}")
 
@@ -68,12 +70,13 @@ def backfill_bridge_blocks(portal_inserter, start_block, end_block):
     print(f"Finished injecting all blocks")
 
 
-def launch_bridge():
+def launch_bridge(provider_arg):
     # Launch trin nodes, for broadcasting data
     # The context manager shuts down all trin nodes on context exit
     trin_node_keys = load_private_keys()
+    w3 = load_provider(provider_arg)
     with launch_trin_inserters(trin_node_keys) as portal_inserter:
-        poll_chain_head(portal_inserter)
+        poll_chain_head(portal_inserter, w3)
 
 
 def launch_injector(content_files):
@@ -82,10 +85,11 @@ def launch_injector(content_files):
         inject_content(portal_inserter, content_files)
 
 
-def launch_backfill(start_block, end_block):
+def launch_backfill(start_block, end_block, provider_arg):
     trin_node_keys = load_private_keys()
+    w3 = load_provider(provider_arg)
     with launch_trin_inserters(trin_node_keys) as portal_inserter:
-        backfill_bridge_blocks(portal_inserter, start_block, end_block)
+        backfill_bridge_blocks(portal_inserter, start_block, end_block, w3)
 
 
 @contextmanager
@@ -120,3 +124,29 @@ def load_private_keys():
             sys.exit(INVALID_KEY_ENV_ERROR)
         else:
             return keys
+
+
+def load_provider(provider_arg):
+    if provider_arg == "custom":
+        try:
+            client_id = os.environ["AUTH_CLIENT_ID"]
+            client_secret = os.environ["AUTH_CLIENT_SECRET"]
+            client_url = os.environ["AUTH_CLIENT_URL"]
+        except KeyError:
+            sys.exit(INVALID_AUTH_PROVIDER_ENV_ERROR)
+        headers = {
+            "headers": {
+                "Content-Type": "application/json",
+                "CF-Access-Client-Id": client_id,
+                "CF-Access-Client-Secret": client_secret,
+            }
+        }
+        w3 = Web3(Web3.HTTPProvider(client_url, request_kwargs=headers))
+        if not w3.isConnected():
+            raise RuntimeError(
+                "Invalid authenticated provider credentials, provider is not connected."
+            )
+    else:
+        from web3.auto.infura import w3
+
+        return w3

--- a/newsfragments/46.feature.rst
+++ b/newsfragments/46.feature.rst
@@ -1,0 +1,1 @@
+Enable option to use custom authenticated provider rather than Infura.


### PR DESCRIPTION
## What was wrong?
Fixes #33 

Issue #

## How was it fixed?
Summary of approach.
Add a cli flag to enable using a custom provider. Aka one of the geth providers provided by devops team.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/199809228-d58019da-739b-4382-a1c9-fdc2d3b21bdf.png)
