### PR TITLE
Support --latest-backfill cli arg

### DIFF
--- a/docs/bridge.rst
+++ b/docs/bridge.rst
@@ -188,6 +188,18 @@ This command will publish the specified blocks, and then shut down. The bridge
 will not try to insert any content besides what you specify here.
 
 
+Patching in recent history
+--------------------------
+
+To import the latest `1000` number of blocks from the current head,
+run this command::
+
+    python -m eth_portal.bridge --patch-recent 1000
+
+This command will publish the specified blocks, and then shut down. The bridge
+will not try to insert any content besides what you specify here.
+
+
 Inject Content Manually
 -------------------------
 

--- a/eth_portal/bridge/__main__.py
+++ b/eth_portal/bridge/__main__.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 
-from .run import launch_backfill, launch_bridge, launch_injector
+from .run import launch_backfill, launch_bridge, launch_injector, launch_patch_recent
 
 # Parse CLI arguments
 parser = ArgumentParser()
@@ -27,6 +27,15 @@ group.add_argument(
         " and publish them into the Portal network."
     ),
 )
+group.add_argument(
+    "--patch-recent",
+    nargs=1,
+    type=int,
+    help=(
+        "Load the N most recent blocks from the current head,"
+        " publish them into the Portal network, and shut down."
+    ),
+)
 parser.add_argument(
     "-p",
     "--provider",
@@ -49,6 +58,8 @@ try:
             )
         else:
             launch_backfill(start, end, args.provider)
+    elif args.patch_recent:
+        launch_patch_recent(args.patch_recent[0], args.provider)
     else:
         raise RuntimeError("Must run bridge with an option. Run with -h to see them.")
 except KeyboardInterrupt:

--- a/eth_portal/bridge/run.py
+++ b/eth_portal/bridge/run.py
@@ -67,7 +67,7 @@ def backfill_bridge_blocks(portal_inserter, start_block, end_block, w3):
         print(f"Injecting block hash {block_fields.hash.hex()}")
         propagate_block(w3, portal_inserter, block_fields)
 
-    print(f"Finished injecting all blocks")
+    print("Finished injecting all blocks")
 
 
 def launch_bridge(provider_arg):
@@ -88,6 +88,18 @@ def launch_injector(content_files):
 def launch_backfill(start_block, end_block, provider_arg):
     trin_node_keys = load_private_keys()
     w3 = load_provider(provider_arg)
+    with launch_trin_inserters(trin_node_keys) as portal_inserter:
+        backfill_bridge_blocks(portal_inserter, start_block, end_block, w3)
+
+
+def launch_patch_recent(blocks_to_patch, provider_arg):
+    trin_node_keys = load_private_keys()
+    w3 = load_provider(provider_arg)
+    end_block = w3.eth.get_block("latest").get("number")
+    if blocks_to_patch > end_block:
+        start_block = 0
+    else:
+        start_block = end_block - blocks_to_patch
     with launch_trin_inserters(trin_node_keys) as portal_inserter:
         backfill_bridge_blocks(portal_inserter, start_block, end_block, w3)
 

--- a/newsfragments/47.feature.rst
+++ b/newsfragments/47.feature.rst
@@ -1,0 +1,1 @@
+Support --patch-recent cli flag to backfill the most recent N blocks from head.


### PR DESCRIPTION
## What was wrong?

During sync we've been discussing initial goals for data availability on the portal network. A first "target" we settled upon was measuring the availability of the most recent `X` number of blocks. Starting with something like `1000` for the value of `X` and then gradually increasing this number. In terms of "dockerizing" the bridge, it would be nice to have a cli option that will backfill the "latest" X number of blocks and then exit. In which case the deployment script will restart the bridge and re-run the backfill, with the latest head. 

Issue #

## How was it fixed?

I'm not sure if this is the most aesthetically pleasing option. I'm definitely open to alternatives. I played around with supporting some other implementations...
- `--latest 1000` 
- `--block-range 1000 latest` (ie. "backfill the 1000 latest blocks")

In the end, it was simpler to just introduce a new flag rather than try and get clever with the existing arguments. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/206144495-40eb0f2e-688b-423b-910c-6ca433684e9e.png)

