### PR TITLE
Pin tox to the locally-tested version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ common: &common
           - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-v2
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: pip install --user tox==3.14.6
     - run:
         name: run tox
         command: python -m tox -r


### PR DESCRIPTION
## What was wrong?

Doc build failed on main. It was running a recent version of tox that renamed the keyword "whitelist_externals" to "allowlist_externals".

## How was it fixed?

When running locally, tox uses the version in the [test] extra. Be sure to use the same one when running in CircleCI.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/1rdVTm1JbcE/hqdefault.jpg)
