### PR TITLE
fix: change portal RPC call from offer to gossip

### DIFF
--- a/eth_portal/bridge/insert.py
+++ b/eth_portal/bridge/insert.py
@@ -63,7 +63,7 @@ class PortalInserter:
     @staticmethod
     def offer_hex_content(w3, key, val):
         try:
-            return w3.provider.make_request("portal_historyOffer", [key, val])
+            return w3.provider.make_request("portal_historyGossip", [key, val])
         except FileNotFoundError:
             # Retry if we just tried to hit the portal client too fast
             for num_polls in range(100):


### PR DESCRIPTION
## What was wrong?

The inserter was using the `portal_historyOffer` RPC, which was [renamed to `portal_historyGossip`](https://github.com/ethereum/portal-network-specs/pull/179).

## How was it fixed?

Change RPC call from `portal_historyOffer` to `portal_historyGossip`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-portal.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-portal/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
